### PR TITLE
Clicking on risk score leads to show analyses page

### DIFF
--- a/app/javascript/events.vue
+++ b/app/javascript/events.vue
@@ -28,7 +28,6 @@
           <th class='desktop'>
             1-hr Risk w/ 1 Infector
           </th>
-          <th class='desktop'>Show Analysis</th>
           <th v-if="adminView">User ID</th>
           <th v-if="adminView">Approve</th>
         </tr>

--- a/app/javascript/measurements_row.vue
+++ b/app/javascript/measurements_row.vue
@@ -238,6 +238,10 @@ export default {
     height: 2em;
   }
 
+  a {
+    text-decoration: none;
+  }
+
   @media (max-width: 800px) {
     .middle-controls {
       display: flex;

--- a/app/javascript/measurements_row.vue
+++ b/app/javascript/measurements_row.vue
@@ -8,30 +8,31 @@
     <td @click="centerMapTo(this.measurements.id)" >{{this.measurements.roomName}}</td>
     <td @click="centerMapTo(this.measurements.id)" >{{this.measurements.placeData.formattedAddress}}</td>
     <td class='containing-cell'>
-      <ColoredCell
-        class='risk-score'
-        :colorScheme="colorInterpolationScheme"
-        :maxVal=1
-        :value='measurements.risk'
-        :text='gradeLetter(this.measurements.risk)'
-        :style="{'font-weight': 'bold', color: 'white', 'text-shadow': '1px 1px 2px black' }"
-        :title='roundOut(measurements.risk, 6)'
-        :exception='{ "text": "NA", "value": 0, color: {r: 200, g: 200, b: 200}}'
-      />
+      <router-link :to='link' @click="showAnalysis(this.measurements.id)">
+        <ColoredCell
+          class='risk-score'
+          :colorScheme="colorInterpolationScheme"
+          :maxVal=1
+          :value='measurements.risk'
+          :text='gradeLetter(this.measurements.risk)'
+          :style="{'font-weight': 'bold', color: 'white', 'text-shadow': '1px 1px 2px black' }"
+          :title='roundOut(measurements.risk, 6)'
+          :exception='{ "text": "NA", "value": 0, color: {r: 200, g: 200, b: 200}}'
+        />
+      </router-link>
     </td>
     <td class='containing-cell desktop'>
-      <ColoredCell
-        class='risk-score'
-        :colorScheme="colorInterpolationScheme"
-        :maxVal=1
-        :value='roundOut(nullIntervention.computeRisk(1), 6)'
-        :text='gradeLetter(nullIntervention.computeRisk(1))'
-        :style="{'font-weight': 'bold', color: 'white', 'text-shadow': '1px 1px 2px black' }"
-        :title='roundOut(nullIntervention.computeRisk(1), 6)'
-      />
-    </td>
-    <td class='desktop'>
-      <router-link :to='link' @click="showAnalysis(this.measurements.id)">Show Analysis</router-link>
+      <router-link :to='link' @click="showAnalysis(this.measurements.id)">
+        <ColoredCell
+          class='risk-score'
+          :colorScheme="colorInterpolationScheme"
+          :maxVal=1
+          :value='roundOut(nullIntervention.computeRisk(1), 6)'
+          :text='gradeLetter(nullIntervention.computeRisk(1))'
+          :style="{'font-weight': 'bold', color: 'white', 'text-shadow': '1px 1px 2px black' }"
+          :title='roundOut(nullIntervention.computeRisk(1), 6)'
+        />
+      </router-link>
     </td>
     <td v-if='adminView'>{{ measurements.authorId }}</td>
     <td v-if='adminView && approvable'>


### PR DESCRIPTION
Before:

<img width="1339" alt="Screen Shot 2022-09-14 at 9 16 07 PM" src="https://user-images.githubusercontent.com/2751152/190290599-78ae9049-312f-4037-9565-724ce04f64cb.png">

After:

<img width="1346" alt="Screen Shot 2022-09-14 at 9 15 48 PM" src="https://user-images.githubusercontent.com/2751152/190290621-99e00c7b-0b7e-4102-9bdb-c804cc2aa78e.png">

Clicking on one of the circles leads to the analytics page:

<img width="1367" alt="Screen Shot 2022-09-14 at 9 17 26 PM" src="https://user-images.githubusercontent.com/2751152/190290694-094a2445-af86-4ff9-b246-4c98bba60a9d.png">
